### PR TITLE
Update main.py

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     # Get data loader
     imsize = cfg.TREE.BASE_SIZE * (2 ** (cfg.TREE.BRANCH_NUM - 1))
     image_transform = transforms.Compose([
-        transforms.Scale(int(imsize * 76 / 64)),
+        transforms.Resize(int(imsize * 76 / 64)),
         transforms.RandomCrop(imsize),
         transforms.RandomHorizontalFlip()])
     dataset = TextDataset(cfg.DATA_DIR, split_dir,


### PR DESCRIPTION
he torchvision.transforms.Scale method has been deprecated and removed in recent versions of torchvision. You should replace it with torchvision.transforms.Resize.

Here’s how you can update the code to use transforms.Resize instead of transforms.Scale:

Locate the Use of transforms.Scale:

Find the lines in your code where transforms.Scale is used. According to your traceback, it seems to be around line 124 in main.py.

Replace transforms.Scale with transforms.Resize:

transforms.Scale(int(imsize * 76 / 64)),

to:

transforms.Resize(int(imsize * 76 / 64)),
Example
Here’s an example of how your main.py might look after the change:

import torchvision.transforms as transforms

# Example usage of transforms.Resize instead of transforms.Scale transform = transforms.Compose([
    transforms.Resize(int(imsize * 76 / 64)),
    transforms.ToTensor(),
    # Add other transformations as needed
])